### PR TITLE
On existing PR, continue to avoid outright failure

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -51,6 +51,7 @@ jobs:
 
       - name: Check for existing automated PR
         id: existing
+        continue-on-error: true
         if: steps.commit.outcome == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is not really a failed workflow, and is normal behaviour. The
subsequent steps check that the previous steps are successful, so they
will not run in case of failure here.