### PR TITLE
Check diff of README.md only

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -34,7 +34,7 @@ jobs:
         id: diff
         continue-on-error: true
         run: |
-          ! git diff --exit-code
+          ! git diff --exit-code "README.md"
 
       - name: Add files and commit
         id: commit


### PR DESCRIPTION
Avoids failure caused by `go.sum` being updated during workflow run, but
no changes added to commit (because the commit is based only on
`README.md`).